### PR TITLE
Add --interpolate and --strict-interpolate CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 We follow semantic versioning.
 
 
+## 1.8.0
+
+### Features
+
+- Adds `--interpolate` CLI option to expand `${VAR}` references in values
+- Adds `--strict-interpolate` CLI option to fail on undefined or malformed references
+
+
 ## 1.7.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -137,6 +137,52 @@ $ dump-env -t .env.template -p SECRET_ --no-quote-values > .env
 By default, `dump-env` quotes values with spaces and other special
 characters to preserve compatibility with .env parsers.
 
+
+### Interpolation
+
+You can expand `${VAR}` references between values with the `-i` or `--interpolate` flag:
+
+```bash
+$ cat .env.template
+DB_HOST=localhost
+DB_URL=postgresql://${DB_HOST}:5432/mydb
+```
+
+```bash
+$ dump-env -t .env.template -p SECRET_ENV_ --interpolate
+DB_HOST=localhost
+DB_URL=postgresql://localhost:5432/mydb
+```
+
+References are resolved after all sources are merged, so environment overrides are respected:
+
+```bash
+$ export SECRET_ENV_DB_HOST='db.internal'
+$ dump-env -t .env.template -p SECRET_ENV_ --interpolate
+DB_HOST=db.internal
+DB_URL=postgresql://db.internal:5432/mydb
+```
+
+Values are expanded once, in definition order. You need to define variables before referencing them.
+A reference to an unknown variable is kept as a literal `${VAR}`, and `$$` produces a literal `$`.
+
+Templates need no quoting: `${VAR}` is read from the file as-is.
+For shell `export`s, the quoting picks who expands the reference:
+
+```bash
+$ export DB_URL="postgresql://${DB_HOST}:5432/mydb"   # the shell expands it at export time
+$ export DB_URL='postgresql://${DB_HOST}:5432/mydb'   # dump-env expands it when it runs
+```
+
+Add `--strict-interpolate` to fail on undefined or malformed references:
+
+```bash
+$ export SECRET_ENV_APP_URL='https://${APP_DOMAIN}/api'
+$ dump-env -p SECRET_ENV_ --interpolate --strict-interpolate
+Unresolved references in: APP_URL ('APP_DOMAIN')
+```
+
+
 ## Creating secret variables in some CIs
 
 - [travis docs](https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ DB_URL=postgresql://db.internal:5432/mydb
 Values are expanded once, in definition order. You need to define variables before referencing them.
 A reference to an unknown variable is kept as a literal `${VAR}`, and `$$` produces a literal `$`.
 
+`$VAR` and `${VAR}` are equivalent - they both expand the variable `VAR`.
+Braces are required when the text directly after the reference would otherwise be read as part
+of the variable name:
+`${HOST}_SUFFIX` expands `HOST` and appends `_SUFFIX`,
+while `$HOST_SUFFIX` is a reference to a single variable named `HOST_SUFFIX`.
+
 Templates need no quoting: `${VAR}` is read from the file as-is.
 For shell `export`s, the quoting picks who expands the reference:
 

--- a/dump_env/cli.py
+++ b/dump_env/cli.py
@@ -99,13 +99,24 @@ def _create_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         '--strict-source',
-        action='store_true',
+        action='store_true',  # noqa: WPS226
         help='All source template variables should exist in os envs',
     )
     parser.add_argument(
         '--no-quote-values',
         action='store_true',
         help='Do not quote values in the output',
+    )
+    parser.add_argument(
+        '-i',
+        '--interpolate',
+        action='store_true',
+        help='Expand ${VAR} references in values',
+    )
+    parser.add_argument(
+        '--strict-interpolate',
+        action='store_true',
+        help='Fail on undefined or malformed ${VAR} references',
     )
     return parser
 
@@ -173,6 +184,8 @@ def main() -> NoReturn:
             strict_vars,
             args.source,
             args.strict_source,
+            interpolate=args.interpolate,
+            strict_interpolate=args.strict_interpolate,
         )
     except StrictEnvError as exc:
         sys.stderr.write(f'{exc!s}\n')

--- a/dump_env/dumper.py
+++ b/dump_env/dumper.py
@@ -109,7 +109,6 @@ def _interpolate(store: dict[str, str], *, strict: bool) -> dict[str, str]:
 
     Args:
         store: Merged template and environment key-values.
-
         strict: Fail on undefined or malformed ${VAR} references
 
     Returns:
@@ -170,9 +169,7 @@ def dump(  # noqa: C901, WPS211
 
         strict_source: Whether all keys in source template must also be
            presented in env vars.
-
         interpolate: Expand ${VAR} references in values
-
         strict_interpolate: Fail on undefined or malformed ${VAR} reference
 
     Returns:

--- a/dump_env/dumper.py
+++ b/dump_env/dumper.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from os import environ
 from pathlib import Path
+from string import Template
 from typing import Final
 
 from dump_env.exceptions import StrictEnvError
@@ -98,12 +99,53 @@ def _source(source: str, strict_source: bool) -> Store:  # ruff: ignore[boolean-
     return sourced
 
 
-def dump(
+def _interpolate(store: dict[str, str], *, strict: bool) -> dict[str, str]:
+    """
+    Expands ``${VAR}`` references in values using other keys of ``store``.
+
+    A reference to a key defined later or missing from the store
+    is kept as a literal ``${VAR}`` in the output.
+    Use ``$$`` to output a literal ``$``.
+
+    Args:
+        store: Merged template and environment key-values.
+
+        strict: Fail on undefined or malformed ${VAR} references
+
+    Returns:
+        The same store with all values expanded in place
+    """
+    failed: list[str] = []
+
+    for env_name, env_value in store.items():
+        template: Template = Template(env_value)
+
+        if strict:
+            try:
+                store[env_name] = template.substitute(store)
+            except (KeyError, ValueError) as exc:
+                failed.append(f'{env_name} ({exc})')
+                store[env_name] = template.safe_substitute(store)
+        else:
+            store[env_name] = template.safe_substitute(store)
+
+    if failed:
+        raise StrictEnvError(
+            'Unresolved references in: {}'.format(', '.join(failed)),
+        )
+
+    return store
+
+
+def dump(  # noqa: C901, WPS211
     template: str = EMPTY_STRING,
     prefixes: list[str] | None = None,
     strict_keys: set[str] | None = None,
     source: str = EMPTY_STRING,
     strict_source: bool = False,  # ruff: ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    *,
+    interpolate: bool = False,
+    strict_interpolate: bool = False,
 ) -> dict[str, str]:
     """
     This function is used to dump ``.env`` files.
@@ -128,6 +170,10 @@ def dump(
 
         strict_source: Whether all keys in source template must also be
            presented in env vars.
+
+        interpolate: Expand ${VAR} references in values
+
+        strict_interpolate: Fail on undefined or malformed ${VAR} reference
 
     Returns:
         Ordered key-value pairs of dumped env and template variables.
@@ -155,6 +201,10 @@ def dump(
     # Loading env variables from `os.environ`:
     for prefix in prefixes:
         store.update(_preload_existing_vars(prefix))
+
+    # Expand ${VAR} references in values
+    if interpolate:
+        store = _interpolate(store, strict=strict_interpolate)
 
     # Sort keys and keep them ordered:
     return OrderedDict(sorted(store.items()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "poetry-core>=2" ]
 
 [tool.poetry]
 name = "dump-env"
-version = "1.7.0"
+version = "1.8.0"
 description = "A utility tool to create .env files"
 license = "MIT"
 authors = [ "Nikita Sobolev <mail@sobolevn.me>" ]

--- a/tests/test_cli/test_interpolate.py
+++ b/tests/test_cli/test_interpolate.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from tests.conftest import DelegatorFactory
+
+
+def test_interpolate(
+    monkeypatch: pytest.MonkeyPatch,
+    delegator: 'DelegatorFactory',
+) -> None:
+    """Check that cli expands ${VAR} references between values."""
+    monkeypatch.setenv('SOME_TT_HOST', 'localhost')
+    monkeypatch.setenv('SOME_TT_URL', '${HOST}:123/${MISSING_VALUE}')
+
+    variables = delegator('dump-env -p SOME_TT_ --interpolate')
+    assert variables == 'HOST=localhost\nURL=localhost:123/${MISSING_VALUE}\n'
+
+
+def test_strict_interpolate_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    delegator: 'DelegatorFactory',
+) -> None:
+    """Check that cli fails on undefined references in strict mode."""
+    monkeypatch.setenv('SOME_TT_HOST', 'localhost')
+    monkeypatch.setenv('SOME_TT_URL', '${HOST}:123/${MISSING_VALUE}')
+
+    variables = delegator(
+        'dump-env -p SOME_TT_ --interpolate --strict-interpolate',
+    )
+    assert variables == (1, "Unresolved references in: URL ('MISSING_VALUE')\n")

--- a/tests/test_cli/test_interpolate.py
+++ b/tests/test_cli/test_interpolate.py
@@ -10,12 +10,16 @@ def test_interpolate(
     monkeypatch: pytest.MonkeyPatch,
     delegator: 'DelegatorFactory',
 ) -> None:
-    """Check that cli expands ${VAR} references between values."""
+    """Check that cli expands ${VAR} and $VAR references between values."""
     monkeypatch.setenv('SOME_TT_HOST', 'localhost')
-    monkeypatch.setenv('SOME_TT_URL', '${HOST}:123/${MISSING_VALUE}')
+    monkeypatch.setenv('SOME_TT_URL1', '${HOST}:123/${MISSING_VALUE}')
+    monkeypatch.setenv('SOME_TT_URL2', '$HOST:123/$MISSING_VALUE')
+    monkeypatch.setenv('SOME_TT_URL3', '${HOST}_SUFFIX:$HOST_SUFFIX')
 
     variables = delegator('dump-env -p SOME_TT_ --interpolate')
-    assert variables == 'HOST=localhost\nURL=localhost:123/${MISSING_VALUE}\n'
+    assert 'URL1=localhost:123/${MISSING_VALUE}\n' in variables
+    assert 'URL2=localhost:123/$MISSING_VALUE\n' in variables
+    assert 'URL3=localhost_SUFFIX:$HOST_SUFFIX\n' in variables
 
 
 def test_strict_interpolate_missing(


### PR DESCRIPTION
Adds an `--interpolate` flag to expand `${VAR}` references between values so values can be built from other variables.

```bash
$ cat .env.template
DB_HOST=localhost
DB_URL=postgresql://${DB_HOST}:5432/mydb

$ dump-env -t .env.template -p SECRET_ENV_ --interpolate
DB_HOST=localhost
DB_URL=postgresql://localhost:5432/mydb
```

```bash
$ export SECRET_ENV_DB_HOST='db.internal'
$ dump-env -t .env.template -p SECRET_ENV_ --interpolate
DB_HOST=db.internal
DB_URL=postgresql://db.internal:5432/mydb
```

Expansion happens after template and prefixed env vars are merged, so overrides work.

Note: `dump()` was already at complexity and argument limits so I added 2 `noqa` rather than refactoring existing code to keep the PR feature-focused.
